### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/dask-fargate/cdk.out/dask-fargate.template.json
+++ b/dask-fargate/cdk.out/dask-fargate.template.json
@@ -1041,7 +1041,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 300
       },
       "DependsOn": [


### PR DESCRIPTION
CloudFormation templates in amazon-sagemaker-cdk-examples have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.