### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/cron-inference/cdk.out/LambdaCronSagemakerInference.template.json
+++ b/cron-inference/cdk.out/LambdaCronSagemakerInference.template.json
@@ -86,7 +86,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "Environment": {
           "Variables": {
             "endpoint_name": "DEMO-videogames-xgboost-2019-06-18-18-58-35-771",

--- a/cron-train/cdk.out/LambdaCronSagemakerTrain.template.json
+++ b/cron-train/cdk.out/LambdaCronSagemakerTrain.template.json
@@ -81,7 +81,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "Environment": {
           "Variables": {
             "base_name": "video-game-xgboost",

--- a/kinesis-inference/cdk.out/KinesisSagemakerInference.template.json
+++ b/kinesis-inference/cdk.out/KinesisSagemakerInference.template.json
@@ -105,7 +105,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "Environment": {
           "Variables": {
             "endpoint_name": "DEMO-videogames-xgboost-2019-06-18-18-58-35-771",

--- a/stepfn-batch/cdk.out/SM-batch-Inference.template.json
+++ b/stepfn-batch/cdk.out/SM-batch-Inference.template.json
@@ -81,7 +81,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "Environment": {
           "Variables": {
             "transform_job_name": "xgboost-batch-transform",
@@ -185,7 +185,7 @@
             "Arn"
           ]
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.10",
         "Environment": {
           "Variables": {
             "model_name": "xgboost-2019-06-18-19-03-13-823",


### PR DESCRIPTION
CloudFormation templates in amazon-sagemaker-cdk-examples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.